### PR TITLE
Allow user to provide previous FEN

### DIFF
--- a/lc2fen.py
+++ b/lc2fen.py
@@ -33,26 +33,35 @@ def parse_arguments():
     global ACTIVATE_KERAS, ACTIVATE_ONNX, ACTIVATE_TRT
 
     parser = argparse.ArgumentParser(
-        description="Predicts board configurations from images."
+        description="Predicts board configuration(s) (FEN string(s)) from image(s)."
     )
 
-    parser.add_argument("path", help="Path to the image or folder you wish to predict")
+    parser.add_argument(
+        "path", help="Path to the image or folder you wish to predict the FEN(s) for"
+    )
     parser.add_argument(
         "a1_pos",
-        help="Location of the a1 square in the chessboard "
+        help="Location of the a1 square in the chessboard image(s) "
         "(B = bottom, T = top, R = right, L = left)",
         choices=["BL", "BR", "TL", "TR"],
+    )
+    parser.add_argument(
+        "previous_fen",
+        nargs="?",
+        help="FEN string of the previous board position (if "
+        "you are predicting the FEN for a single image and if "
+        "the previous board position is known)",
     )
 
     inf_engine = parser.add_mutually_exclusive_group(required=True)
     inf_engine.add_argument(
-        "-k", "--keras", help="Run inference using Keras", action="store_true"
+        "-k", "--keras", help="run inference using Keras", action="store_true"
     )
     inf_engine.add_argument(
-        "-o", "--onnx", help="Run inference using ONNXRuntime", action="store_true"
+        "-o", "--onnx", help="run inference using ONNXRuntime", action="store_true"
     )
     inf_engine.add_argument(
-        "-t", "--trt", help="Run inference using TensorRT", action="store_true"
+        "-t", "--trt", help="run inference using TensorRT", action="store_true"
     )
 
     args = parser.parse_args()
@@ -66,23 +75,38 @@ def parse_arguments():
     else:
         ValueError("No inference engine selected. This should be unreachable.")
 
-    return args.path, args.a1_pos
+    return args.path, args.a1_pos, args.previous_fen
 
 
 def main():
     """Parses the arguments and prints the predicted FEN."""
-    path, a1_pos = parse_arguments()
+    path, a1_pos, previous_fen = parse_arguments()
     if ACTIVATE_KERAS:
         fen, _ = predict_board_keras(
-            MODEL_PATH_KERAS, IMG_SIZE_KERAS, PRE_INPUT_KERAS, path, a1_pos
+            MODEL_PATH_KERAS,
+            IMG_SIZE_KERAS,
+            PRE_INPUT_KERAS,
+            path,
+            a1_pos,
+            previous_fen=previous_fen,
         )
     elif ACTIVATE_ONNX:
         fen, _ = predict_board_onnx(
-            MODEL_PATH_ONNX, IMG_SIZE_ONNX, PRE_INPUT_ONNX, path, a1_pos
+            MODEL_PATH_ONNX,
+            IMG_SIZE_ONNX,
+            PRE_INPUT_ONNX,
+            path,
+            a1_pos,
+            previous_fen=previous_fen,
         )
     elif ACTIVATE_TRT:
         fen, _ = predict_board_trt(
-            MODEL_PATH_TRT, IMG_SIZE_TRT, PRE_INPUT_TRT, path, a1_pos
+            MODEL_PATH_TRT,
+            IMG_SIZE_TRT,
+            PRE_INPUT_TRT,
+            path,
+            a1_pos,
+            previous_fen=previous_fen,
         )
     else:
         fen = None

--- a/lc2fen/infer_pieces.py
+++ b/lc2fen/infer_pieces.py
@@ -152,8 +152,8 @@ def infer_chess_pieces(pieces_probs, a1_pos, previous_fen=None):
         position of the chessboard given in FEN notation order.
     :param a1_pos: Position of the a1 square. Must be one of the
         following: "BL", "BR", "TL", "TR".
-    :param previous_fen: The FEN string representing the previous move
-        of the same board. If it is not None, improves piece inference.
+    :param previous_fen: FEN string of the previous board position.
+        If it is not None, improves piece inference.
     :return: A list of the inferred chess pieces in FEN notation order.
     """
     pieces_probs = board_to_list(list_to_board(pieces_probs, a1_pos))
@@ -175,7 +175,7 @@ def infer_chess_pieces(pieces_probs, a1_pos, previous_fen=None):
     # We need to store the original order
     pieces_probs_sort = [(probs, i) for i, probs in enumerate(pieces_probs)]
 
-    # First choose the kings, there must be one of each color
+    # First choose the kings (there must be one of each color)
     white_king = max(pieces_probs_sort, key=lambda prob: prob[0][1])
     black_kings = sorted(
         pieces_probs_sort, key=lambda prob: prob[0][8], reverse=True
@@ -190,8 +190,8 @@ def infer_chess_pieces(pieces_probs, a1_pos, previous_fen=None):
 
     out_preds_empty = 62  # We have already set the kings
 
-    # Then set the blank spaces, the CNN has a very high accuracy
-    # detecting these cases
+    # Then set the blank spaces (the CNN has a very high accuracy of
+    # detecting these cases)
     for idx, piece in enumerate(pieces_probs):
         if out_preds[idx] is None:
             if is_empty_square(piece):
@@ -206,7 +206,7 @@ def infer_chess_pieces(pieces_probs, a1_pos, previous_fen=None):
     # probability of any piece for all the board
     pieces_lists = __sort_pieces_list(pieces_probs_sort)
     # Index to the highest probability, from each list in pieces_lists,
-    # that we have not set yet (in the same order than above).
+    # that we have not set yet (in the same order as above).
     idx = [0] * 10
     # Top of each sorted piece list (highest probability of each piece)
     tops = [piece_list[0] for piece_list in pieces_lists]


### PR DESCRIPTION
A feature has been added to allow a user to provide the FEN string of the previous board position when running "lc2fen.py" to predict the FEN for a single image. Help messages have been updated and some comments in the code have been rephrased for grammatical and consistent purposes as well.