### PR TITLE
Conclude fen immediately after move detection

### DIFF
--- a/lc2fen/infer_pieces.py
+++ b/lc2fen/infer_pieces.py
@@ -155,6 +155,62 @@ def __check_bishop(max_idx, tops, w_bishop_sq, b_bishop_sq):
     return True  # If it's not a bishop, nothing to check
 
 
+def __determine_promoted_piece(previous_fen, pieces_probs, final_move_sq, color):
+    """Determines the promoted piece."""
+    promoted_piece_prob = 0
+    if color == "white":
+        if (
+            pieces_probs[final_move_sq][4] > promoted_piece_prob
+            and previous_fen.count("Q") < 2
+        ):
+            promoted_piece = "Q"
+            promoted_piece_prob = pieces_probs[final_move_sq][4]
+        if (
+            pieces_probs[final_move_sq][2] > promoted_piece_prob
+            and previous_fen.count("N") < 2
+        ):
+            promoted_piece = "N"
+            promoted_piece_prob = pieces_probs[final_move_sq][2]
+        if (
+            pieces_probs[final_move_sq][5] > promoted_piece_prob
+            and previous_fen.count("R") < 2
+        ):
+            promoted_piece = "R"
+            promoted_piece_prob = pieces_probs[final_move_sq][5]
+        if (
+            pieces_probs[final_move_sq][0] > promoted_piece_prob
+            and previous_fen.count("B") < 2
+        ):
+            promoted_piece = "B"
+    else:
+        if (
+            pieces_probs[final_move_sq][11] > promoted_piece_prob
+            and previous_fen.count("q") < 2
+        ):
+            promoted_piece = "q"
+            promoted_piece_prob = pieces_probs[final_move_sq][11]
+        if (
+            pieces_probs[final_move_sq][9] > promoted_piece_prob
+            and previous_fen.count("n") < 2
+        ):
+            promoted_piece = "n"
+            promoted_piece_prob = pieces_probs[final_move_sq][9]
+        if (
+            pieces_probs[final_move_sq][12] > promoted_piece_prob
+            and previous_fen.count("r") < 2
+        ):
+            promoted_piece = "r"
+            promoted_piece_prob = pieces_probs[final_move_sq][12]
+        if (
+            pieces_probs[final_move_sq][7] > promoted_piece_prob
+            and previous_fen.count("b") < 2
+        ):
+            promoted_piece = "b"
+    # Note that if the provided previous FEN is correct, `promoted_piece`
+    # should be defined at this point
+    return promoted_piece
+
+
 def infer_chess_pieces(pieces_probs, a1_pos, previous_fen=None):
     """
     Infers the chess pieces in all of the board based on the given
@@ -194,68 +250,18 @@ def infer_chess_pieces(pieces_probs, a1_pos, previous_fen=None):
             if (
                 previous_list[initial_sq] == "P" and initial_coordinates[1] == "7"
             ):  # White promotes (and we have to figure out the promoted piece)
-                promoted_piece_prob = 0
-                if (
-                    pieces_probs[final_move_sq][4] > promoted_piece_prob
-                    and previous_fen.count("Q") < 2
-                ):
-                    promoted_piece = "Q"
-                    promoted_piece_prob = pieces_probs[final_move_sq][4]
-                if (
-                    pieces_probs[final_move_sq][2] > promoted_piece_prob
-                    and previous_fen.count("N") < 2
-                ):
-                    promoted_piece = "N"
-                    promoted_piece_prob = pieces_probs[final_move_sq][2]
-                if (
-                    pieces_probs[final_move_sq][5] > promoted_piece_prob
-                    and previous_fen.count("R") < 2
-                ):
-                    promoted_piece = "R"
-                    promoted_piece_prob = pieces_probs[final_move_sq][5]
-                if (
-                    pieces_probs[final_move_sq][0] > promoted_piece_prob
-                    and previous_fen.count("B") < 2
-                ):
-                    promoted_piece = "B"
-                    promoted_piece_prob = pieces_probs[final_move_sq][0]
-
-                # Note that if the provided previous FEN is correct, `promoted_piece`
-                # should be defined at this point
+                promoted_piece = __determine_promoted_piece(
+                    previous_fen, pieces_probs, final_move_sq, "white"
+                )
                 move_UCI = move_UCI + promoted_piece.lower()
                 previous_board.push_uci(move_UCI)
                 return board_to_list(fen_to_board(previous_board.board_fen()))
             elif (
                 previous_list[initial_sq] == "p" and initial_coordinates[1] == "2"
             ):  # Black promotes (and we have to figure out the promoted piece)
-                promoted_piece_prob = 0
-                if (
-                    pieces_probs[final_move_sq][11] > promoted_piece_prob
-                    and previous_fen.count("q") < 2
-                ):
-                    promoted_piece = "q"
-                    promoted_piece_prob = pieces_probs[final_move_sq][11]
-                if (
-                    pieces_probs[final_move_sq][9] > promoted_piece_prob
-                    and previous_fen.count("n") < 2
-                ):
-                    promoted_piece = "n"
-                    promoted_piece_prob = pieces_probs[final_move_sq][9]
-                if (
-                    pieces_probs[final_move_sq][12] > promoted_piece_prob
-                    and previous_fen.count("r") < 2
-                ):
-                    promoted_piece = "r"
-                    promoted_piece_prob = pieces_probs[final_move_sq][12]
-                if (
-                    pieces_probs[final_move_sq][7] > promoted_piece_prob
-                    and previous_fen.count("b") < 2
-                ):
-                    promoted_piece = "b"
-                    promoted_piece_prob = pieces_probs[final_move_sq][7]
-
-                # Note that if the provided previous FEN is correct, `promoted_piece`
-                # should be defined at this point
+                promoted_piece = __determine_promoted_piece(
+                    previous_fen, pieces_probs, final_move_sq, "black"
+                )
                 move_UCI = move_UCI + promoted_piece
                 previous_board.push_uci(move_UCI)
                 return board_to_list(fen_to_board(previous_board.board_fen()))

--- a/lc2fen/predict_board.py
+++ b/lc2fen/predict_board.py
@@ -313,7 +313,7 @@ def continuous_predictions(path, a1_pos, obtain_pieces_probs):
 def test_predict_board(obtain_predictions):
     """Tests board prediction."""
     fens, a1_squares, previous_fens = read_correct_fen(
-        os.path.join("predictions", "boards.fen")
+        os.path.join("predictions", "boards_with_previous.fen")
     )
 
     for i in range(5):

--- a/lc2fen/predict_board.py
+++ b/lc2fen/predict_board.py
@@ -74,7 +74,7 @@ def predict_board_keras(
         return predictions
 
     if test:
-        test_predict_board(obtain_pieces_probs, previous_fen)
+        test_predict_board(obtain_pieces_probs)
     else:
         if os.path.isdir(path):
             return continuous_predictions(path, a1_pos, obtain_pieces_probs)
@@ -115,7 +115,7 @@ def predict_board_onnx(
         return predictions
 
     if test:
-        test_predict_board(obtain_pieces_probs, previous_fen)
+        test_predict_board(obtain_pieces_probs)
     else:
         if os.path.isdir(path):
             return continuous_predictions(path, a1_pos, obtain_pieces_probs)
@@ -221,7 +221,7 @@ def predict_board_trt(
             return [trt_outputs[ind : ind + 13] for ind in range(0, 13 * 64, 13)]
 
         if test:
-            test_predict_board(obtain_pieces_probs, previous_fen)
+            test_predict_board(obtain_pieces_probs)
         else:
             if os.path.isdir(path):
                 return continuous_predictions(path, a1_pos, obtain_pieces_probs)
@@ -310,18 +310,33 @@ def continuous_predictions(path, a1_pos, obtain_pieces_probs):
             time.sleep(0.1)
 
 
-def test_predict_board(obtain_predictions, previous_fen=None):
+def test_predict_board(obtain_predictions):
     """Tests board prediction."""
-    fens, a1_squares = read_correct_fen(os.path.join("predictions", "boards.fen"))
+    fens, a1_squares, previous_fens = read_correct_fen(
+        os.path.join("predictions", "boards.fen")
+    )
 
     for i in range(5):
         fen = time_predict_board(
             os.path.join("predictions", "test" + str(i + 1) + ".jpg"),
             a1_squares[i],
             obtain_predictions,
-            previous_fen,
         )
-        print_fen_comparison("test" + str(i + 1) + ".jpg", fen, fens[i])
+        print_fen_comparison(
+            "test" + str(i + 1) + ".jpg",
+            fen,
+            fens[i],
+            False,
+        )
+
+        if previous_fens[i] is not None:
+            fen = time_predict_board(
+                os.path.join("predictions", "test" + str(i + 1) + ".jpg"),
+                a1_squares[i],
+                obtain_predictions,
+                previous_fens[i],
+            )
+            print_fen_comparison("test" + str(i + 1) + ".jpg", fen, fens[i], True)
 
 
 def detect_input_board(board_path, board_corners=None):
@@ -426,7 +441,7 @@ def time_predict_board(board_path, a1_pos, obtain_pieces_probs, previous_fen=Non
     return fen
 
 
-def print_fen_comparison(board_name, fen, correct_fen):
+def print_fen_comparison(board_name, fen, correct_fen, used_previous_fen):
     """
     Compares the predicted fen with the correct fen and pretty prints
     the result.
@@ -434,13 +449,18 @@ def print_fen_comparison(board_name, fen, correct_fen):
     :param board_name: Name of the board. For example: 'test1.jpg'
     :param fen: Predicted fen string.
     :param correct_fen: Correct fen string.
+    :param used_previous_fen: Whether previous fen was used during prediction.
     """
     n_dif = compare_fen(fen, correct_fen)
+    used_previous_fen_str = (
+        "_with_previous_fen" if used_previous_fen else "_without_previous_fen"
+    )
     print(
         board_name[:-4]
+        + used_previous_fen_str
         + " - Err:"
         + str(n_dif)
-        + " Acc:{:.2f}% FEN:".format(1 - (n_dif / 64))
+        + " Acc:{:.2f}% FEN:".format((1 - (n_dif / 64)) * 100)
         + fen
         + "\n"
     )
@@ -450,22 +470,28 @@ def read_correct_fen(fen_file):
     """
     Reads the correct fen for testing from fen_file.
 
-    :param board_path: Path to the file containing the correct fens and
-        a1 squares.
-    :return: List with the correct fens and list with the correct
-        a1 squares.
+    :param board_path: Path to the file containing the correct fens,
+        a1 squares, and (optionally) correct previous fens.
+    :return: List with the correct fens, list with the correct
+        a1 squares, and list with correct previous fens.
     """
     fens = []
     a1_squares = []
+    previous_fens = []
 
     with open(fen_file, "r") as fen_fd:
         lines = fen_fd.read().splitlines()
         for line in lines:
             line = line.split()
-            if len(line) != 2:
+            if not len(line) in [2, 3]:
                 raise ValueError(
-                    "All lines in fen file must have the format " "'fen orientation'"
+                    "All lines in fen file must have the format "
+                    "'fen orientation [previous_fen]'"
                 )
             fens.append(line[0])
             a1_squares.append(line[1])
-    return fens, a1_squares
+            if len(line) == 2:
+                previous_fens.append(None)
+            else:
+                previous_fens.append(line[2])
+    return fens, a1_squares, previous_fens


### PR DESCRIPTION
With the `chess` library, FEN can now be concluded immediately upon successful move detection. This drastically increases the prediction accuracy. Here is part of the testing output with "MobileNetV2_0p5_all.onnx":
<img width="756" alt="image" src="https://github.com/davidmallasen/LiveChess2FEN/assets/51491203/7fc2585f-04fb-4365-ba2c-8adc5223c52a">
(The first four tests have all resulted in 100% accuracies, and the reason this new feature does not make a difference on the fifth test is because the "MobileNetV2_0p5_all.onnx" model is not accurate enough; it thinks there is a white piece on the d7 square when in reality there is a black knight on that square, so move detection failed during the prediction.)

@davidmallasen Could you upload the "boards.fen" file from [boards.zip](https://github.com/davidmallasen/LiveChess2FEN/files/11952141/boards.zip) to the [releases](https://github.com/davidmallasen/LiveChess2FEN/releases)? The "boards.fen" file from the initial release would still work with my code, but I think it makes sense to update this now so the previous FENs are included during testing (so anyone can obtain the above output). Side note: the previous FENs I included in "boards.fen" were quite arbitrary (based on my educated guess on how the position could've arisen), so feel free to change them or add more test images.

Many comments in this "infer_pieces.py" have been rephrased for clarity and grammar as well.



